### PR TITLE
feed: add description

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,6 @@
 title: Syslog
 url: https://syslog.show
+description: "Flo and Julian talk to their guests about engineering microkernels, operating systems and the community around these technologies."
 
 author_url: "http://ukvly.org/"
 email: "podcast@ukvly.org"

--- a/general_feed.xml
+++ b/general_feed.xml
@@ -9,6 +9,7 @@ layout: null
   <link href="{{ site.url }}"/>
   <updated>{{ site.time | date_to_xmlschema }}</updated>
   <id>{{ site.url }}/</id>
+  <description>{{ site.description }}</description>
   <author>
     <name>{{ site.author }}</name>
     <email>{{ site.email }}</email>


### PR DESCRIPTION
Adds a description field to the Feed. We could probably improve the description further, but we need that field in the feed to submit the podcast to the iTunes directory.